### PR TITLE
Throw error with correct serviceName on long syntax depends_on error

### DIFF
--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -386,9 +386,9 @@ describe('compose-go parsing & validation', () => {
 			} catch (error) {
 				expect(error).to.be.instanceOf(ServiceError);
 				expect(error.message).to.equal(
-					'Long syntax depends_on {"condition":"service_healthy","restart":true,"required":true} for service "db" is not yet supported',
+					'Long syntax depends_on db:{"condition":"service_healthy","restart":true,"required":true} for service "web" is not yet supported',
 				);
-				expect(error.serviceName).to.equal('db');
+				expect(error.serviceName).to.equal('web');
 			}
 		});
 


### PR DESCRIPTION
Given a service `main` that expresses long syntax depends_on on service `other`, if the long syntax depends_on config is not supported, this commit corrects the thrown ServiceError to reference `main` instead of `other`, as `main` is the service config with the unsupported depends_on config, not `other`.

Change-type: patch