### PR TITLE
Move tar package to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "mocha": "^11.7.2",
     "rimraf": "^6.0.1",
     "sinon": "^21.0.0",
-    "tar": "^7.4.3",
     "ts-mocha": "^11.1.0",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
@@ -62,6 +61,7 @@
   },
   "dependencies": {
     "semver": "^7.7.2",
+    "tar": "^7.5.1",
     "typed-error": "^3.2.2"
   },
   "versionist": {


### PR DESCRIPTION
`tar` is needed by scripts/fetch-binary.js, which needs to be able to run even when only production NPM dependencies are installed.

Change-type: patch