### PR TITLE
Use sw.spec/compose instead of sw.compose contract type

### DIFF
--- a/lib/compose.ts
+++ b/lib/compose.ts
@@ -773,14 +773,18 @@ function createImageDescriptor(
 ): ImageDescriptor {
 	let contract = createContractFromLabels(serviceName, service.labels);
 
-	// If the service uses newly supported compose fields, add a sw.compose
+	// If the service uses newly supported compose fields, add a sw.spec/compose
 	// contract requirement so that legacy Supervisors can reject the composition.
 	// Version 2 corresponds to Compose Spec v2: https://docs.docker.com/reference/compose-file/
 	if (usesNewComposeFields(service)) {
 		console.warn(
 			`Service "${serviceName}" uses compose fields that may not be supported on legacy Supervisor versions`,
 		);
-		const composeRequirement = { type: 'sw.compose', version: '>=2' };
+		const composeRequirement = {
+			type: 'sw.spec',
+			slug: 'compose',
+			version: '>=2',
+		};
 		if (contract && 'requires' in contract) {
 			(contract.requires as any[]).push(composeRequirement);
 		} else {

--- a/lib/legacy.ts
+++ b/lib/legacy.ts
@@ -2,7 +2,7 @@ import type { Service } from './types';
 
 // Fields newly supported by balena-compose-parser that were
 // not supported by balena-compose previously. If a service uses any of these fields,
-// we add a sw.compose contract requirement so that legacy Supervisors which don't support
+// we add a sw.spec/compose contract requirement so that legacy Supervisors which don't support
 // the new compose fields can gracefully reject the composition.
 // TODO: When long syntax depends_on and long syntax volumes are supported
 // (i.e. their rejections in normalizeService are removed), add them here.

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -1378,12 +1378,16 @@ describe('compose-go parsing & validation', () => {
 			});
 		});
 
-		it('should add sw.compose contract if newly supported compose fields are present', async () => {
+		it('should add sw.spec/compose contract if newly supported compose fields are present', async () => {
 			const composition = await parse(
 				'test/fixtures/compose/services/newly_supported.yml',
 			);
 			const descriptors = toImageDescriptors(composition);
-			const composeRequirement = { type: 'sw.compose', version: '>=2' };
+			const composeRequirement = {
+				type: 'sw.spec',
+				slug: 'compose',
+				version: '>=2',
+			};
 			// Service with newly supported top-level fields
 			const main = descriptors.find((d) => d.serviceName === 'main');
 			expect(main?.contract)
@@ -1403,7 +1407,7 @@ describe('compose-go parsing & validation', () => {
 				.that.deep.includes(composeRequirement);
 		});
 
-		it('should not add sw.compose contract if only already-supported compose fields are present', async () => {
+		it('should not add sw.spec/compose contract if only already-supported compose fields are present', async () => {
 			const composition = await parse(
 				'test/fixtures/compose/services/no_newly_supported.yml',
 			);

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -284,7 +284,7 @@ describe('createContractFromLabels', () => {
 		});
 	});
 
-	it('should add sw.compose contract for services with newly supported fields', () => {
+	it('should add sw.spec/compose contract for services with newly supported fields', () => {
 		const composition: Composition = {
 			services: {
 				app: {
@@ -297,11 +297,11 @@ describe('createContractFromLabels', () => {
 		expect(descriptors[0].contract).to.deep.equal({
 			type: 'sw.container',
 			slug: 'contract-for-app',
-			requires: [{ type: 'sw.compose', version: '>=2' }],
+			requires: [{ type: 'sw.spec', slug: 'compose', version: '>=2' }],
 		});
 	});
 
-	it('should not add sw.compose contract for services without newly supported fields', () => {
+	it('should not add sw.spec/compose contract for services without newly supported fields', () => {
 		const composition: Composition = {
 			services: {
 				app: {
@@ -314,7 +314,7 @@ describe('createContractFromLabels', () => {
 		expect(descriptors[0].contract).to.be.undefined;
 	});
 
-	it('should merge sw.compose contract with existing contract requirements', () => {
+	it('should merge sw.spec/compose contract with existing contract requirements', () => {
 		const composition: Composition = {
 			services: {
 				app: {
@@ -332,7 +332,7 @@ describe('createContractFromLabels', () => {
 			slug: 'contract-for-app',
 			requires: [
 				{ type: 'sw.supervisor', version: '>=16.0.0' },
-				{ type: 'sw.compose', version: '>=2' },
+				{ type: 'sw.spec', slug: 'compose', version: '>=2' },
 			],
 		});
 	});


### PR DESCRIPTION
The compose spec is more semantically a specification, so use type: sw.spec with slug: compose rather than type: sw.compose.

Change-type: patch