### PR TITLE
Support all ipc values except service:${serviceName}

### DIFF
--- a/lib/compose.ts
+++ b/lib/compose.ts
@@ -306,7 +306,10 @@ function normalizeService(
 	}
 
 	// Reject service.ipc which references service:${serviceName} as Supervisor doesn't support this yet
-	if (service.ipc && service.ipc !== 'shareable') {
+	if (
+		typeof service.ipc === 'string' &&
+		service.ipc.trim().startsWith('service:')
+	) {
 		throw new ServiceError(
 			'service.ipc which references service:${serviceName} is not supported',
 			serviceName,

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -550,6 +550,29 @@ describe('compose-go parsing & validation', () => {
 			});
 		});
 
+		it('should accept service.ipc: host', async () => {
+			const composition = await parse(
+				'test/fixtures/compose/services/ipc_host.yml',
+			);
+			expect(composition).to.deep.equal({
+				services: {
+					main: {
+						image: 'alpine:latest',
+						command: ['sh', '-c', 'sleep infinity'],
+						ipc: 'host',
+						networks: {
+							default: null,
+						},
+					},
+				},
+				networks: {
+					default: {
+						ipam: {},
+					},
+				},
+			});
+		});
+
 		it('should reject service.ipc which references service:${serviceName}', async () => {
 			try {
 				await parse('test/fixtures/compose/services/ipc.yml');

--- a/test/fixtures/compose/services/ipc_host.yml
+++ b/test/fixtures/compose/services/ipc_host.yml
@@ -1,0 +1,5 @@
+services:
+  main:
+    image: alpine:latest
+    command: sh -c "sleep infinity"
+    ipc: host


### PR DESCRIPTION
Although not documented in the official docker compose docs, `ipc: host`, `ipc: private`, `ipc: none`, etc. values are supported.

Change-type: patch