### PR TITLE
Convert extra_hosts separator from `=` to `:`

### DIFF
--- a/lib/compose.ts
+++ b/lib/compose.ts
@@ -429,6 +429,14 @@ function normalizeService(
 		}
 	}
 
+	// compose-go normalizes extra_hosts to `host=ip`, but our Engine expects `host:ip`
+	// as does latest Moby. Convert the separator back.
+	if (service.extra_hosts) {
+		service.extra_hosts = service.extra_hosts.map((entry) =>
+			entry.replace('=', ':'),
+		);
+	}
+
 	// Delete label_file, as compose-go adds label_file labels to service.labels
 	delete service.label_file;
 
@@ -515,6 +523,15 @@ function normalizeServiceBuild(
 		build.context =
 			path.relative(path.dirname(composeFilePath), build.context) || '.';
 	}
+
+	// compose-go normalizes extra_hosts to `host=ip`, but our Engine expects `host:ip`
+	// as does latest Moby. Convert the separator back.
+	if (build.extra_hosts) {
+		build.extra_hosts = build.extra_hosts.map((entry) =>
+			entry.replace('=', ':'),
+		);
+	}
+
 	return build;
 }
 

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -87,7 +87,7 @@ describe('compose-go parsing & validation', () => {
 							ENV_TWO: 'val_two',
 							ENV_THREE: 'val_three',
 						},
-						extra_hosts: ['foo=127.0.0.1'],
+						extra_hosts: ['foo:127.0.0.1'],
 						volumes: ['v2:/v2:ro'],
 					},
 					s3: {
@@ -97,7 +97,7 @@ describe('compose-go parsing & validation', () => {
 							default: null,
 						},
 						ports: ['1000', '1001:1002', '1003:1004'],
-						extra_hosts: ['bar=8.8.8.8'],
+						extra_hosts: ['bar:8.8.8.8'],
 						tmpfs: ['/tmp1', '/tmp2'],
 						volumes: ['v1:/v1'],
 					},
@@ -227,7 +227,7 @@ describe('compose-go parsing & validation', () => {
 						environment: {
 							ENV_TEST: 'true',
 						},
-						extra_hosts: ['host1=127.0.0.1', 'host2=127.0.0.2'],
+						extra_hosts: ['host1:127.0.0.1', 'host2:127.0.0.2'],
 						group_add: ['mail', '1111'],
 						healthcheck: {
 							test: ['CMD', 'curl', '-f', 'http://localhost:8080'],
@@ -314,7 +314,7 @@ describe('compose-go parsing & validation', () => {
 						environment: {
 							ENV_TEST_2: 'true',
 						},
-						extra_hosts: ['host3=127.0.0.3', 'host4=127.0.0.4'],
+						extra_hosts: ['host3:127.0.0.3', 'host4:127.0.0.4'],
 						ipc: 'shareable',
 						labels: {
 							'com.example.label3': 'value3',
@@ -1492,7 +1492,7 @@ describe('compose-go parsing & validation', () => {
 								ARG2: 'value2',
 							},
 							cache_from: ['my_cache', 'my_cache2'],
-							extra_hosts: ['host1=127.0.0.1', 'host2=127.0.0.2'],
+							extra_hosts: ['host1:127.0.0.1', 'host2:127.0.0.2'],
 							labels: {
 								'com.example.label': 'value',
 								'com.example.label2': 'value2',


### PR DESCRIPTION
compose-go normalises extra_hosts to `=` separator,
however neither Moby nor balenaEngine support =, both expect :.

Change-type: patch