### PR TITLE
Support apparmor/seccomp=unconfined for security_opt

### DIFF
--- a/lib/compose.ts
+++ b/lib/compose.ts
@@ -293,11 +293,31 @@ function normalizeService(
 		);
 	}
 
-	// Reject all security_opt settings except no-new-privileges
-	if (service.security_opt?.some((opt) => !opt.match('no-new-privileges'))) {
+	// Reject all security_opt settings except no-new-privileges, unconfined apparmor/seccomp.
+	// compose-go preserves the original separator, which can be `:` or `=`, so accept both.
+	// Note: `systempaths=unconfined` is intentionally not allowed, as balenaEngine
+	// does not handle it in parseSecurityOpt and rejects container creation.
+	const allowedSecurityOpts = [
+		/^no-new-privileges([:=].*)?$/,
+		/^apparmor[:=]unconfined$/,
+		/^seccomp[:=]unconfined$/,
+	];
+	if (
+		service.security_opt?.some(
+			(opt) => !allowedSecurityOpts.some((re) => re.test(opt)),
+		)
+	) {
 		throw new ServiceError(
-			'Only no-new-privileges is allowed for service.security_opt',
+			'Only no-new-privileges and unconfined apparmor and seccomp are allowed for service.security_opt',
 			serviceName,
+		);
+	}
+
+	// Normalize the security_opt separator to `=`. Moby and balenaEngine parse
+	// `key=value`, and treat `key:value` as accepted but deprecated.
+	if (service.security_opt) {
+		service.security_opt = service.security_opt.map((opt) =>
+			opt.replace(':', '='),
 		);
 	}
 

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -1021,21 +1021,32 @@ describe('compose-go parsing & validation', () => {
 			});
 		});
 
-		it('should reject all security_opt settings except no-new-privileges', async () => {
+		it('should reject unsupported security_opt settings', async () => {
 			try {
 				await parse(
 					'test/fixtures/compose/services/unsupported/security_opt_unsupported.yml',
 				);
 				expect.fail(
-					'Expected compose parser to reject security_opt settings except no-new-privileges',
+					'Expected compose parser to reject unsupported security_opt settings',
 				);
 			} catch (error) {
 				expect(error).to.be.instanceOf(ServiceError);
 				expect(error.serviceName).to.equal('main');
 				expect(error.message).to.equal(
-					'Only no-new-privileges is allowed for service.security_opt',
+					'Only no-new-privileges and unconfined apparmor and seccomp are allowed for service.security_opt',
 				);
 			}
+		});
+
+		it('should allow no-new-privileges and unconfined apparmor and seccomp in security_opt, normalizing the separator to `=`', async () => {
+			const composition = await parse(
+				'test/fixtures/compose/services/security_opt_supported.yml',
+			);
+			expect(composition.services.main.security_opt).to.deep.equal([
+				'no-new-privileges=true',
+				'apparmor=unconfined',
+				'seccomp=unconfined',
+			]);
 		});
 
 		it('should reject volumes of type bind', async () => {

--- a/test/fixtures/compose/services/security_opt_supported.yml
+++ b/test/fixtures/compose/services/security_opt_supported.yml
@@ -1,0 +1,8 @@
+services:
+  main:
+    image: alpine:latest
+    command: sh -c "sleep infinity"
+    security_opt:
+      - no-new-privileges:true
+      - apparmor=unconfined
+      - seccomp:unconfined

--- a/test/fixtures/compose/services/unsupported/security_opt_unsupported.yml
+++ b/test/fixtures/compose/services/unsupported/security_opt_unsupported.yml
@@ -9,7 +9,6 @@ services:
       - label:role:balena
       - label:disable
       - apparmor:MY_PROFILE
-      - seccomp:unconfined
       - seccomp:builtin
       - seccomp:profile.json
       - systempaths:unconfined


### PR DESCRIPTION
These opts are used for balena-on-balena, and although balenaOS does not support them as of v7 launch, they are desireable in a hardened balenaOS so we would like to add them down the line.

Change-type: patch