### PR TITLE
Support service.profiles

### DIFF
--- a/lib/compose.ts
+++ b/lib/compose.ts
@@ -218,10 +218,6 @@ export const SERVICE_CONFIG_DENY_LIST = [
 	'memswap_limit',
 	'oom_kill_disable',
 	'platform',
-	// TODO: Currently compose-go does not include a service with profiles set if they're not specified in COMPOSE_PROFILES,
-	// so a composition with profiles doesn't actually reject as the profiles are not added to the parsed compose by compose-go.
-	// We should support profiles which will involve modifying this code, but in dedicated shaping + building cycles.
-	// 'profiles',
 	'pull_policy',
 	'runtime',
 	'scale',
@@ -231,6 +227,8 @@ export const SERVICE_CONFIG_DENY_LIST = [
 ];
 
 const OOM_SCORE_ADJ_WARN_THRESHOLD = -900;
+
+const PROFILE_NAME_REGEX = /^[a-zA-Z0-9][a-zA-Z0-9_.-]+$/;
 
 const bindMountByLabel: Array<[string, string[]]> = [
 	['io.balena.features.balena-socket', ['/var/run/docker.sock']],
@@ -261,6 +259,17 @@ function normalizeService(
 	for (const field of SERVICE_CONFIG_DENY_LIST) {
 		if (field in service) {
 			throw new ServiceError(`service.${field} is not allowed`, serviceName);
+		}
+	}
+
+	if (service.profiles != null) {
+		for (const profile of service.profiles) {
+			if (!PROFILE_NAME_REGEX.test(profile)) {
+				throw new ServiceError(
+					`service.profiles "${profile}" is not a valid profile name`,
+					serviceName,
+				);
+			}
 		}
 	}
 

--- a/lib/main.go
+++ b/lib/main.go
@@ -90,6 +90,9 @@ func main() {
 		cli.WithOsEnv,
 		cli.WithDotEnv,
 		cli.WithName(projectName),
+		// "*" keeps profiled services in the output; compose-go otherwise
+		// filters them out and only marshals `profiles` for enabled services.
+		cli.WithProfiles([]string{"*"}),
 	)
 	if err != nil {
 		outputError("ConfigError", fmt.Sprintf("Failed to create compose project options: %v", err))

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -120,10 +120,7 @@ interface ServiceImageMount extends ServiceVolumeBase {
 }
 
 export type ServiceVolumeConfig =
-	| ServiceBindMount
-	| ServiceVolumeMount
-	| ServiceTmpfsMount
-	| ServiceImageMount;
+	ServiceBindMount | ServiceVolumeMount | ServiceTmpfsMount | ServiceImageMount;
 
 export interface BuildConfig {
 	additional_contexts?: Dict<string>; // Normalized from ListOrDict<string>
@@ -244,7 +241,7 @@ export interface Service {
 	post_start?: LifecycleHook[];
 	pre_stop?: LifecycleHook[];
 	privileged?: boolean;
-	// profiles?: string[]; While a field in the raw yaml file, this isn't included in the parsed composition
+	profiles?: string[];
 	pull_policy?: string;
 	read_only?: boolean;
 	restart?: string;

--- a/test/compose.spec.ts
+++ b/test/compose.spec.ts
@@ -1049,6 +1049,33 @@ describe('compose-go parsing & validation', () => {
 			]);
 		});
 
+		it('should preserve profiles on services that declare them', async () => {
+			const composition = await parse(
+				'test/fixtures/compose/services/profiles.yml',
+			);
+			// Services with profiles must be kept, not filtered out by compose-go
+			expect(composition.services.main.profiles).to.equal(undefined);
+			expect(composition.services.debug.profiles).to.deep.equal([
+				'debug',
+				'trace-2.0',
+			]);
+		});
+
+		it('should reject invalid profile names', async () => {
+			try {
+				await parse(
+					'test/fixtures/compose/services/unsupported/profiles_invalid.yml',
+				);
+				expect.fail('Expected compose parser to reject invalid profile names');
+			} catch (error) {
+				expect(error).to.be.instanceOf(ServiceError);
+				expect(error.serviceName).to.equal('main');
+				expect(error.message).to.equal(
+					'service.profiles "invalid profile!" is not a valid profile name',
+				);
+			}
+		});
+
 		it('should reject volumes of type bind', async () => {
 			try {
 				await parse(

--- a/test/fixtures/compose/services/profiles.yml
+++ b/test/fixtures/compose/services/profiles.yml
@@ -1,0 +1,8 @@
+services:
+  main:
+    image: alpine
+  debug:
+    image: busybox
+    profiles:
+      - debug
+      - trace-2.0

--- a/test/fixtures/compose/services/unsupported/profiles_invalid.yml
+++ b/test/fixtures/compose/services/unsupported/profiles_invalid.yml
@@ -1,0 +1,5 @@
+services:
+  main:
+    image: alpine
+    profiles:
+      - "invalid profile!"


### PR DESCRIPTION
Profiles were previously dropped by compose-go. compose-go does have composition filtering using `cli.withProfiles` which we don't want, as the API should be filtering profiles in target state for runtime activation.

Enable the "*" wildcard so every profiled service is kept and its `profiles` field is marshaled, surface it on the Service type, and validate profile names against the Docker profile name format.

Change-type: minor